### PR TITLE
Add rotten api wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/cs2340-group3/moviebuzz",
   "dependencies": {
-    "express": "4.12.4"
+    "express": "4.12.4",
+    "rotten-api": "0.0.2"
   }
 }


### PR DESCRIPTION
We probably need this extension to have access to Rotten Tomatoes API.
