### PR TITLE
Fix a bug after login failure

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -36,7 +36,10 @@ router.post('/login', function(req, res, next) {
         return next(err); // will generate a 500 error
       }
       if (!user) {
-        return res.render('login', { message: info.message });
+        return res.render('login', {
+          message: info.message
+          , csrfToken: req.csrfToken()
+        });
       }
       req.login(user, function(err) {
         if(err) {
@@ -59,8 +62,10 @@ router.route('/register')
       req.body.password,
       function(err) {
         if (err) {
-          return res.render("register", { message: err });
-          // return next(err);
+          return res.render("register", {
+            message: err
+            , csrfToken: req.csrfToken()
+          });
         }
         passport.authenticate('local')(req, res, function() {
         res.redirect('/');
@@ -78,7 +83,7 @@ router.get('/profile', function(req, res) {
   if(req.session.passport.user === undefined) {
     res.redirect('/login');
   } else {
-    res.render('profile', {username: req.user.username});
+    res.render('profile', { username: req.user.username });
   }
 });
 


### PR DESCRIPTION
I did not put CSRF token into the form after failure. For the previous version, if you submit a wrong password, you cannot login through the returned form.
