### PR TITLE
Fix bower postinstall for real

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
     "body-parser": "^1.12.4",
+    "bower": "^1.4.1",
     "cookie-parser": "^1.3.5",
     "csurf": "^1.8.2",
     "express": "4.12.4",
@@ -38,8 +39,5 @@
     "passport-local-mongoose": "^1.0.0",
     "rotten-api": "0.0.2",
     "serve-favicon": "^2.2.1"
-  },
-  "devDependencies": {
-    "bower": "^1.4.1"
   }
 }


### PR DESCRIPTION
I tested it this time and it works. >_<

When Heroku is deploying it only installs production dependencies, not dev dependencies. And it makes sense for bower to be a production dependency: it's required to deploy on production.
