### PR TITLE
Block banned user from login

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -28,6 +28,12 @@ router.route('/login')
             , csrfToken: req.csrfToken()
           });
         }
+        if (user.banned) {
+          return res.status(403).json({
+            message: "You are banned"
+            , csrfToken: req.csrfToken()
+          });
+        }
         req.login(user, function(err) {
           if(err) {
             return res.status(403).json({


### PR DESCRIPTION
An issue with my implementation is that Passport.js first checks if the password is correct and _then_ checks if the user is banned. The order isn't good because if a banned user tried to login with a wrong password, he would first get wrong password warning rather than a warning of him being banned.

It happens because I put the added if statement in the callback of `passport.authenticate()`. However, if I added the code before that, I had to make another database retrieval.
